### PR TITLE
Updated version to 1.2.8.  TransactionStatus Request and Response Ser…

### DIFF
--- a/DataMeshGroup.Fusion/DataMeshGroup.Fusion.csproj
+++ b/DataMeshGroup.Fusion/DataMeshGroup.Fusion.csproj
@@ -11,7 +11,7 @@
     <PackageId>DataMeshGroup.Fusion.FusionClient</PackageId>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageLicenseFile></PackageLicenseFile>
-    <Version>1.2.7</Version>
+    <Version>1.2.8</Version>
     <RepositoryUrl>https://github.com/datameshgroup/sdk-dotnet</RepositoryUrl>
     <PackageReleaseNotes>Fixed production bug preventing TLS1.2 connection under some conditions</PackageReleaseNotes>
   </PropertyGroup>

--- a/DataMeshGroup.Fusion/FusionClient.cs
+++ b/DataMeshGroup.Fusion/FusionClient.cs
@@ -380,6 +380,10 @@ namespace DataMeshGroup.Fusion
         /// <exception cref="NetworkException">A network error occured sending the request</exception>
         public async Task<SaleToPOIMessage> SendAsync(MessagePayload requestMessage, string serviceID, bool ensureConnectedAndLoginComplete, System.Threading.CancellationToken cancellationToken)
         {
+            Log(LogLevel.Trace, $"Clear Request ServiceID and Message Reference ServiceID before request message processing.");
+            lastTxnServiceID = String.Empty;
+            lastMessageRefServiceID = String.Empty;
+
             SaleToPOIMessage saleToPOIRequest;
             string s;
             try
@@ -428,7 +432,6 @@ namespace DataMeshGroup.Fusion
             }
 
             // Record lastTxnServiceID. Special handling for AbortRequest and the message reference Service ID for TransactionStatusRequest, all other messages record the ServiceID we use in the MessageHeader
-            lastMessageRefServiceID = string.Empty;
             if (requestMessage is TransactionStatusRequest)
             {
                 // For a TransactionStatus we validate also the ServiceID in the RepeatedMessageResponse

--- a/DataMeshGroup.Fusion/FusionClient.cs
+++ b/DataMeshGroup.Fusion/FusionClient.cs
@@ -380,10 +380,6 @@ namespace DataMeshGroup.Fusion
         /// <exception cref="NetworkException">A network error occured sending the request</exception>
         public async Task<SaleToPOIMessage> SendAsync(MessagePayload requestMessage, string serviceID, bool ensureConnectedAndLoginComplete, System.Threading.CancellationToken cancellationToken)
         {
-            Log(LogLevel.Trace, $"Clear Request ServiceID and Message Reference ServiceID before request message processing.");
-            lastTxnServiceID = String.Empty;
-            lastMessageRefServiceID = String.Empty;
-
             SaleToPOIMessage saleToPOIRequest;
             string s;
             try
@@ -621,19 +617,16 @@ namespace DataMeshGroup.Fusion
                         if (messagePayload is TransactionStatusResponse)
                         {
                             TransactionStatusResponse tr = messagePayload as TransactionStatusResponse;
-                            if (tr != null)
-                            {
-                                if (tr.RepeatedMessageResponse != null)
-                                    responseServiceID = tr.RepeatedMessageResponse.MessageHeader?.ServiceID;
-                                else
-                                    responseServiceID = tr.MessageReference?.ServiceID;
+                            if (tr.RepeatedMessageResponse != null)
+                                responseServiceID = tr.RepeatedMessageResponse.MessageHeader?.ServiceID;
+                            else //Failure - In Progress
+                                responseServiceID = tr.MessageReference?.ServiceID;
 
-                                Log(LogLevel.Trace, $"Response Message Reference ServiceID = {responseServiceID}");
-                                if (!string.IsNullOrEmpty(responseServiceID) && !lastMessageRefServiceID.Equals(responseServiceID))
-                                {
-                                    Log(LogLevel.Error, $"Unexpected Message Reference ServiceID ({responseServiceID}) received in {messagePayload.GetType()}.  Expected value is {lastMessageRefServiceID}.  Will process the next message instead.");
-                                    continue;
-                                }
+                            Log(LogLevel.Trace, $"Response Message Reference ServiceID = {responseServiceID}");
+                            if (!string.IsNullOrEmpty(responseServiceID) && !lastMessageRefServiceID.Equals(responseServiceID))
+                            {
+                                Log(LogLevel.Error, $"Unexpected Message Reference ServiceID ({responseServiceID}) received in {messagePayload.GetType()}.  Expected value is {lastMessageRefServiceID}.  Will process the next message instead.");
+                                continue;
                             }
                         }
                     }

--- a/DataMeshGroup.Fusion/Model/QueuedMessagePayload.cs
+++ b/DataMeshGroup.Fusion/Model/QueuedMessagePayload.cs
@@ -1,0 +1,20 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace DataMeshGroup.Fusion.Model
+{
+    public class QueuedMessagePayload
+    {
+        public QueuedMessagePayload(string serviceID, MessagePayload messagePayload)
+        {
+            ServiceID = serviceID; 
+            MessagePayload = messagePayload;
+        }
+
+        public string ServiceID { get; set; }
+        public MessagePayload MessagePayload { get; set; }
+    }
+}


### PR DESCRIPTION
…viceIDs handling update.

Updated version to 1.2.8.  Updated TransactionStatus Request and Response handling so that both the actual message TransactionStatus request's ServiceID and message reference ServiceID are verified against the TransactionStatus response's ServiceID and message reference ServiceID.  Previously only the message reference ServiceID in the TransactionStatus request and response are being verified if they match.